### PR TITLE
Attributes and properties

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -50,7 +50,7 @@
             <my-element></my-element>
         </div>
         <script>
-          document.querySelector('#markdown').markdown = "This **demo** uses the `markdown` _attribute_, not `src`";
+            document.querySelector('#markdown').markdown = "This **demo** uses the `markdown` _attribute_, not `src`";
         </script>
     </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,9 +13,7 @@
             // import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
             // import '@polymer/iron-demo-helpers/demo-snippet';
         </script>
-
         <script type="module" src="../markdown-element.js"></script>
-
         <style>
             body {
                 font-family: 'Helvetica', sans-serif;
@@ -26,7 +24,7 @@
         <div class="vertical-section-container centered">
             <h1>Basic markdown-element demo</h1>
             <h2><code>markdown</code> attribute</h2>
-            <markdown-element markdown="This **demo** uses the `markdown` _attribute_, not `src`"></markdown-element>
+            <markdown-element id="markdown"></markdown-element>
             <h2><code>src</code> attribute</h2>
             <markdown-element src="./demo.md"></markdown-element>
             <h2><code>src</code> not a markdown file</h2>
@@ -49,6 +47,10 @@
                     This <button onclick="alert('JavaScript executed')">button</button> is evil
                 </script>
             </markdown-element>
+            <my-element></my-element>
         </div>
+        <script>
+          document.querySelector('#markdown').markdown = "This **demo** uses the `markdown` _attribute_, not `src`";
+        </script>
     </body>
 </html>

--- a/markdown-element.js
+++ b/markdown-element.js
@@ -4,8 +4,8 @@ import 'commonmark/dist/commonmark.js';
 import 'prismjs/prism.js';
 
 class MarkdownElement extends LitElement {
-    
-    _render({ renderedMarkdown }) {        
+
+    _render() {
         return html`
             <style>
 
@@ -16,7 +16,7 @@ class MarkdownElement extends LitElement {
                 }
 
             </style>
-            ${ renderedMarkdown }
+            ${ this.renderedMarkdown }
         `;
     }
 
@@ -25,17 +25,16 @@ class MarkdownElement extends LitElement {
             markdown: String,
             src: String,
             scriptTag: Object,
-            renderedMarkdown: String,
             safe: Boolean
         };
     }
 
     // render the markdown using the `markdown` attribute
     // `markdown` is set either by the user or the component
-    set markdown(markdown) {
-        this
-            .renderMarkdown(markdown)
-            .then(r => this.renderedMarkdown = r)
+    get renderedMarkdown() {
+        return this.markdown ?
+          this.renderMarkdown(this.markdown) :
+          '';
     }
 
     // fetch the markdown using the `src` attribute
@@ -49,17 +48,16 @@ class MarkdownElement extends LitElement {
     // set the markdown from the script tag, trimming the whitespace
     // note: overrides `src` and `markdown` attributes
     set scriptTag(scriptTag) {
-        if(scriptTag) this.markdown = scriptTag.text.trim();
+        if (scriptTag) this.markdown = scriptTag.text.trim();
     }
 
     connectedCallback() {
         super.connectedCallback();
         // look for a script tag
         this.scriptTag = this.querySelector('script[type="text/markdown"]');
-        
     }
 
-    async _didRender() {
+    _didRender() {
         // after render, highlight text
         Prism.highlightAllUnder(this.shadowRoot, false);
     }
@@ -72,7 +70,7 @@ class MarkdownElement extends LitElement {
             .catch(e => 'Failed to read Markdown source.')
     }
 
-    async renderMarkdown(markdown) {
+    renderMarkdown(markdown) {
         // parse and render Markdown
         const reader = new commonmark.Parser();
         const writer = new commonmark.HtmlRenderer({ safe: this.safe });

--- a/markdown-element.js
+++ b/markdown-element.js
@@ -33,8 +33,8 @@ class MarkdownElement extends LitElement {
     // `markdown` is set either by the user or the component
     get renderedMarkdown() {
         return this.markdown ?
-          this.renderMarkdown(this.markdown) :
-          '';
+            this.renderMarkdown(this.markdown) :
+            '';
     }
 
     // fetch the markdown using the `src` attribute
@@ -48,7 +48,7 @@ class MarkdownElement extends LitElement {
     // set the markdown from the script tag, trimming the whitespace
     // note: overrides `src` and `markdown` attributes
     set scriptTag(scriptTag) {
-        if (scriptTag) this.markdown = scriptTag.text.trim();
+        if(scriptTag) this.markdown = scriptTag.text.trim();
     }
 
     connectedCallback() {


### PR DESCRIPTION
These changes get the application of `markdown` as an property to work. I've outlined this by doing so in the demo page.

Notice that I've moved `renderedMarkdown` from a property to a getter. This allows lit-element to manage the `markdown` property full-time. As they weren't actually `async`, I updated the definitions of `_didRender` along with `renderMarkdown`, which  being part of the getter should be syncronous by default.

I can't explain why it wasn't working before, so maybe this isn't helpful, but I think it gets you on to the next thing?